### PR TITLE
Enable master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ciper
 
-Easily instantiate a PR test workflow with jenkins and github
+Easily instantiate a PR and a master branch test workflow with jenkins and github.
 
 ## install
 
@@ -11,7 +11,7 @@ npm i ciper --save
 ## example
 
 Use ciper to poll the github API for various organizations to sync projects of
-those organizations with jenkins in order for Test PR webhooks to work
+those organizations with jenkins in order for Test PR and master branch webhooks to work
 seamlessly
 
 ```js
@@ -24,7 +24,8 @@ var ciper = new Ciper({
   },
   jenkins: 'http://myjenkinsurl',
   credentialsId: 'uuid', // pretend this is a UUID
-  gitHubAuthId: '' // TODO: figure out what this is used for with the github plugin
+  gitHubAuthId: '' // TODO: figure out what this is used for with the github plugin,
+  type: 'master' // Allowed values: ['master', 'pr']
 });
 
 //
@@ -40,7 +41,7 @@ ciper.poll(3E6)
     console.log('Github poll started');
   })
   .on('poll:finish', function () {
-    console.log('Github poll finished, repos synced'); 
+    console.log('Github poll finished, repos synced');
   })
 
 ```

--- a/build-master.xml
+++ b/build-master.xml
@@ -1,0 +1,154 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>Build and test {name} based on a pull request.</description>
+  <logRotator class="hudson.tasks.LogRotator">
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>5</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.14.0">
+      <projectUrl>https://github.secureserver.net/{short}</projectUrl>
+    </com.coravy.hudson.plugins.github.GithubProjectProperty>
+    <com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty plugin="naginator@1.15">
+      <optOut>false</optOut>
+    </com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty>
+    <jenkins.plugins.slack.SlackNotifier_-SlackJobProperty plugin="slack@1.8">
+      <teamDomain></teamDomain>
+      <token></token>
+      <room></room>
+      <startNotification>false</startNotification>
+      <notifySuccess>false</notifySuccess>
+      <notifyAborted>false</notifyAborted>
+      <notifyNotBuilt>false</notifyNotBuilt>
+      <notifyUnstable>false</notifyUnstable>
+      <notifyFailure>false</notifyFailure>
+      <notifyBackToNormal>false</notifyBackToNormal>
+      <notifyRepeatedFailure>false</notifyRepeatedFailure>
+      <includeTestSummary>false</includeTestSummary>
+      <showCommitList>false</showCommitList>
+      <includeCustomMessage>false</includeCustomMessage>
+      <customMessage></customMessage>
+    </jenkins.plugins.slack.SlackNotifier_-SlackJobProperty>
+  </properties>
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@2.4.0">
+    <configVersion>2</configVersion>
+    <userRemoteConfigs>
+      <hudson.plugins.git.UserRemoteConfig>
+        <refspec>+refs/pull/*:refs/remotes/origin/pr/*</refspec>
+        <url>{repo}</url>
+        <credentialsId>{credentialsId}</credentialsId>
+      </hudson.plugins.git.UserRemoteConfig>
+    </userRemoteConfigs>
+    <branches>
+      <hudson.plugins.git.BranchSpec>
+        <name>{branchName}</name>
+      </hudson.plugins.git.BranchSpec>
+    </branches>
+    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+    <submoduleCfg class="list"/>
+    <extensions/>
+  </scm>
+  <assignedNode>{nodeType}</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+    <com.cloudbees.jenkins.GitHubPushTrigger plugin="github@1.13.3">
+      <spec/>
+    </com.cloudbees.jenkins.GitHubPushTrigger>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>set +x -e
+
+source /usr/local/cicd/node/nvm.sh
+nvm install {node}
+
+if [ ! -d node_modules ]; then
+  npm install
+fi
+npm test</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.plugins.cobertura.CoberturaPublisher plugin="cobertura@1.9.7">
+      <coberturaReportFile>coverage/cobertura-coverage.xml</coberturaReportFile>
+      <onlyStable>false</onlyStable>
+      <failUnhealthy>false</failUnhealthy>
+      <failUnstable>false</failUnstable>
+      <autoUpdateHealth>false</autoUpdateHealth>
+      <autoUpdateStability>false</autoUpdateStability>
+      <zoomCoverageChart>false</zoomCoverageChart>
+      <maxNumberOfBuilds>0</maxNumberOfBuilds>
+      <failNoReports>false</failNoReports>
+      <healthyTarget>
+        <targets class="enum-map" enum-type="hudson.plugins.cobertura.targets.CoverageMetric">
+          <entry>
+            <hudson.plugins.cobertura.targets.CoverageMetric>METHOD</hudson.plugins.cobertura.targets.CoverageMetric>
+            <int>0</int>
+          </entry>
+          <entry>
+            <hudson.plugins.cobertura.targets.CoverageMetric>LINE</hudson.plugins.cobertura.targets.CoverageMetric>
+            <int>0</int>
+          </entry>
+          <entry>
+            <hudson.plugins.cobertura.targets.CoverageMetric>CONDITIONAL</hudson.plugins.cobertura.targets.CoverageMetric>
+            <int>0</int>
+          </entry>
+        </targets>
+      </healthyTarget>
+      <unhealthyTarget>
+        <targets class="enum-map" enum-type="hudson.plugins.cobertura.targets.CoverageMetric">
+          <entry>
+            <hudson.plugins.cobertura.targets.CoverageMetric>METHOD</hudson.plugins.cobertura.targets.CoverageMetric>
+            <int>0</int>
+          </entry>
+          <entry>
+            <hudson.plugins.cobertura.targets.CoverageMetric>LINE</hudson.plugins.cobertura.targets.CoverageMetric>
+            <int>0</int>
+          </entry>
+          <entry>
+            <hudson.plugins.cobertura.targets.CoverageMetric>CONDITIONAL</hudson.plugins.cobertura.targets.CoverageMetric>
+            <int>0</int>
+          </entry>
+        </targets>
+      </unhealthyTarget>
+      <failingTarget>
+        <targets class="enum-map" enum-type="hudson.plugins.cobertura.targets.CoverageMetric">
+          <entry>
+            <hudson.plugins.cobertura.targets.CoverageMetric>METHOD</hudson.plugins.cobertura.targets.CoverageMetric>
+            <int>0</int>
+          </entry>
+          <entry>
+            <hudson.plugins.cobertura.targets.CoverageMetric>LINE</hudson.plugins.cobertura.targets.CoverageMetric>
+            <int>0</int>
+          </entry>
+          <entry>
+            <hudson.plugins.cobertura.targets.CoverageMetric>CONDITIONAL</hudson.plugins.cobertura.targets.CoverageMetric>
+            <int>0</int>
+          </entry>
+        </targets>
+      </failingTarget>
+      <sourceEncoding>ASCII</sourceEncoding>
+    </hudson.plugins.cobertura.CoberturaPublisher>
+  </publishers>
+  <buildWrappers>
+    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.15">
+      <strategy class="hudson.plugins.build_timeout.impl.NoActivityTimeOutStrategy">
+        <timeoutSecondsString>600</timeoutSecondsString>
+      </strategy>
+      <operationList>
+        <hudson.plugins.build__timeout.operations.FailOperation/>
+      </operationList>
+    </hudson.plugins.build__timeout.BuildTimeoutWrapper>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.1">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
+</project>

--- a/build-master.xml
+++ b/build-master.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <project>
   <actions/>
-  <description>Build and test {name} based on a pull request.</description>
+  <description>Build and test master branch for {name}.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
     <numToKeep>5</numToKeep>

--- a/build.xml
+++ b/build.xml
@@ -45,7 +45,7 @@
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>${{sha1}}</name>
+        <name>{branchName}</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ var format = require('string-template');
 var debug = require('diagnostics')('ciper');
 
 module.exports = Ciper;
-
 //
 // 1. I need to add the hook events for both the git and github plugin into
 // jenkins that will only trigger on PR and comments for a repo. Ensure the repo
@@ -37,6 +36,7 @@ function Ciper(options) {
   //
   this.admins = options.admins || [];
   this.nodeType = options.nodeType || '';
+  this.isMaster = options.isMaster || false;
 
   //
   // Other properties that need to be templated into the jenkins build
@@ -365,7 +365,9 @@ Ciper.prototype.createJob = function (pkg, callback) {
     //
     // XXX. Maybe make this more configurable in the future
     //
-    this.jenkins.job.create([name, 'build', 'pr'].join('-'),
+    var jobName = [name, 'build', this.isMaster ? 'master' : 'pr'].join('-');
+    console.log('job name: ', jobName);
+    this.jenkins.job.create(jobName,
       this.templateXml(xml, assign({
         admins: this.admins.join(' '),
         orgs: (this.organizations || []).join(' '),

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function Ciper(options) {
   //
   this.admins = options.admins || [];
   this.nodeType = options.nodeType || '';
-  this.isMaster = options.isMaster || false;
+  this.type = options.type || 'pr';
 
   //
   // Other properties that need to be templated into the jenkins build
@@ -365,8 +365,8 @@ Ciper.prototype.createJob = function (pkg, callback) {
     //
     // XXX. Maybe make this more configurable in the future
     //
-    var jobName = [name, 'build', this.isMaster ? 'master' : 'pr'].join('-');
-    var branchName = this.isMaster ? 'master' : '${{sha1}}';
+    var jobName = [name, 'build', this.type].join('-');
+    var branchName = this.type === 'pr' ? '${{sha1}}' : this.type;
     debug({
       jobName: jobName,
       branchName: branchName
@@ -393,7 +393,7 @@ Ciper.prototype.createJob = function (pkg, callback) {
  */
 Ciper.prototype.deleteJob = function (pkg, callback) {
   var name = pkg.name;
-  var jobName = [name, 'build', this.isMaster ? 'master' : 'pr'].join('-');
+  var jobName = [name, 'build', this.type].join('-');
 
   this.jenkins.job.destroy(jobName, callback);
 };
@@ -412,7 +412,7 @@ Ciper.prototype.templateXml = function (xml, pkg) {
  */
 Ciper.prototype.createHooks = function (repo, callback) {
 
-  var githubEvents = this.isMaster ? ['push'] : ['pull_request', 'pull_request_review_comment', 'issue_comment'];
+  var githubEvents = this.type !== 'pr' ? ['push'] : ['pull_request', 'pull_request_review_comment', 'issue_comment'];
 
   async.parallel([
     this.makeHook.bind(this, repo, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciper",
-  "version": "1.1.5",
+  "version": "1.1.4",
   "description": "A CI-PR creator that queries the github API and creates jobs in jenkins for running tests on PR",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciper",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A CI-PR creator that queries the github API and creates jobs in jenkins for running tests on PR",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciper",
   "version": "1.1.4",
-  "description": "A CI-PR creator that queries the github API and creates jobs in jenkins for running tests on PR",
+  "description": "A CI-PR creator that queries the github API and creates jobs in jenkins for running tests on PR and master",
   "main": "index.js",
   "scripts": {
     "test": "istanbul cover _mocha test.js"


### PR DESCRIPTION
Enabled creation of jenkins build master job by adding new flag on ciper config:

``` js
var ciper = new Ciper({
  organizations: ['nodejitsu', 'warehouseai', 'godaddy']
  github: {
    url: 'https://api.github.com'
  },
  jenkins: 'http://myjenkinsurl',
  credentialsId: 'uuid', // pretend this is a UUID
  gitHubAuthId: '' // TODO: figure out what this is used for with the github plugin,
  type: 'master' // < - ADDED THIS
});
```

<img width="757" alt="screen shot 2016-04-27 at 10 21 39 am" src="https://cloud.githubusercontent.com/assets/8496184/14861592/cf41c74e-0c62-11e6-93db-f7eccb5e3171.png">
<img width="685" alt="screen shot 2016-04-27 at 10 22 22 am" src="https://cloud.githubusercontent.com/assets/8496184/14861593/cf42246e-0c62-11e6-8837-1baf66d01a35.png">
